### PR TITLE
Drop support for FreeBSD 11.4

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,23 +1,28 @@
 # Test the documentation on SSH hardening
 task:
   matrix:
-    - name: 14-CURRENT
-      freebsd_instance:
-        image_family: freebsd-14-0-snap
-    - name: 13.0-RELEASE
-      freebsd_instance:
-        image_family: freebsd-13-0
     - name: 12.2-RELEASE
       freebsd_instance:
         image_family: freebsd-12-2
-    - name: 11.4-RELEASE
+    - name: 12.2-STABLE
       freebsd_instance:
-        image_family: freebsd-11-4
-  script:
+        image_family: freebsd-12-2-snap
+    - name: 13.0-RELEASE
+      freebsd_instance:
+        image_family: freebsd-13-0
+    - name: 13.0-STABLE
+      freebsd_instance:
+        image_family: freebsd-13-0-snap
+    - name: 14.0-CURRENT
+      freebsd_instance:
+        image_family: freebsd-14-0-snap
+  ssh-hardening_script:
     - sed -i '' 's/^/#/' README.md
+    - sed -i '' '/^#         .*$/d' README.md
     - sed -i '' 's/^#    //' README.md
-    - echo "#\!/bin/sh\n$(cat README.md)" > freebsd-ssh-hardening.sh
-    - sh ./freebsd-ssh-hardening.sh
-  ssh_audit_artifacts:
-    path: ssh-audit.out
-    type: text/plain
+    - printf "#\!/bin/sh\nset -e\n%s\n" "$(cat README.md)" > ssh-hardening.sh
+    - sh ./ssh-hardening.sh
+  always:
+    ssh-audit.out_artifacts:
+      path: ssh-audit.out
+      type: text/plain

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@
     sudo -s # we need root for most of this
     cp -a /etc/ssh /etc/ssh.bak # backup ssh config just in case
     pkg install -y security/py-ssh-audit # install ssh-audit (you can make intall if you like)
-    rehash
 
 ## Enable and start sshd, then run ssh-audit, saving the output
 
     service sshd enable
     service sshd start
-    ssh-audit --no-colors localhost > ssh-audit.out
+    uname -a > ssh-audit.out
+    echo "# before hardening" >> ssh-audit.out
+    ssh-audit --no-colors localhost >> ssh-audit.out || true
 
 ## Remove existing key-pairs, disable DSA & ECDSA, regenerate RSA and ED25519 keys
 
@@ -40,10 +41,137 @@
 ## Restart sshd and run ssh-audit again, appending output
 
     service sshd restart
+    echo "# after hardening" >> ssh-audit.out
     ssh-audit --no-colors localhost >> ssh-audit.out
-    uname -a >> ssh-audit.out
 
-Send (pastebin) the contents of `ssh-audit.out`
+<details>
+  <summary>Send (pastebin) the contents of <code>ssh-audit.out</code></summary>
+
+```
+FreeBSD cirrus-task-0000000000000000 14.0-CURRENT FreeBSD 14.0-CURRENT #0 main-n249268-58a7bf124cc: Thu Sep  9 12:00:00 UTC 2021     root@releng1.nyi.freebsd.org:/usr/obj/usr/src/amd64.amd64/sys/GENERIC  amd64
+# before hardening
+# general
+(gen) banner: SSH-2.0-OpenSSH_8.7 FreeBSD-20210907
+(gen) software: OpenSSH 8.7 running on FreeBSD (2021-09-07)
+(gen) compatibility: OpenSSH 7.4+, Dropbear SSH 2018.76+
+(gen) compression: enabled (zlib@openssh.com)
+
+# key exchange algorithms
+(kex) curve25519-sha256                     -- [info] available since OpenSSH 7.4, Dropbear SSH 2018.76
+(kex) curve25519-sha256@libssh.org          -- [info] available since OpenSSH 6.5, Dropbear SSH 2013.62
+(kex) ecdh-sha2-nistp256                    -- [fail] using weak elliptic curves
+                                            `- [info] available since OpenSSH 5.7, Dropbear SSH 2013.62
+(kex) ecdh-sha2-nistp384                    -- [fail] using weak elliptic curves
+                                            `- [info] available since OpenSSH 5.7, Dropbear SSH 2013.62
+(kex) ecdh-sha2-nistp521                    -- [fail] using weak elliptic curves
+                                            `- [info] available since OpenSSH 5.7, Dropbear SSH 2013.62
+(kex) diffie-hellman-group-exchange-sha256 (2048-bit) -- [info] available since OpenSSH 4.4
+(kex) diffie-hellman-group16-sha512         -- [info] available since OpenSSH 7.3, Dropbear SSH 2016.73
+(kex) diffie-hellman-group18-sha512         -- [info] available since OpenSSH 7.3
+(kex) diffie-hellman-group14-sha256         -- [info] available since OpenSSH 7.3, Dropbear SSH 2016.73
+
+# host-key algorithms
+(key) rsa-sha2-512 (3072-bit)               -- [info] available since OpenSSH 7.2
+(key) rsa-sha2-256 (3072-bit)               -- [info] available since OpenSSH 7.2
+(key) ssh-rsa (3072-bit)                    -- [fail] using weak hashing algorithm
+                                            `- [info] available since OpenSSH 2.5.0, Dropbear SSH 0.28
+                                            `- [info] a future deprecation notice has been issued in OpenSSH 8.2: https://www.openssh.com/txt/release-8.2
+(key) ecdsa-sha2-nistp256                   -- [fail] using weak elliptic curves
+                                            `- [warn] using weak random number generator could reveal the key
+                                            `- [info] available since OpenSSH 5.7, Dropbear SSH 2013.62
+(key) ssh-ed25519                           -- [info] available since OpenSSH 6.5
+
+# encryption algorithms (ciphers)
+(enc) chacha20-poly1305@openssh.com         -- [info] available since OpenSSH 6.5
+                                            `- [info] default cipher since OpenSSH 6.9.
+(enc) aes128-ctr                            -- [info] available since OpenSSH 3.7, Dropbear SSH 0.52
+(enc) aes192-ctr                            -- [info] available since OpenSSH 3.7
+(enc) aes256-ctr                            -- [info] available since OpenSSH 3.7, Dropbear SSH 0.52
+(enc) aes128-gcm@openssh.com                -- [info] available since OpenSSH 6.2
+(enc) aes256-gcm@openssh.com                -- [info] available since OpenSSH 6.2
+
+# message authentication code algorithms
+(mac) umac-64-etm@openssh.com               -- [warn] using small 64-bit tag size
+                                            `- [info] available since OpenSSH 6.2
+(mac) umac-128-etm@openssh.com              -- [info] available since OpenSSH 6.2
+(mac) hmac-sha2-256-etm@openssh.com         -- [info] available since OpenSSH 6.2
+(mac) hmac-sha2-512-etm@openssh.com         -- [info] available since OpenSSH 6.2
+(mac) hmac-sha1-etm@openssh.com             -- [warn] using weak hashing algorithm
+                                            `- [info] available since OpenSSH 6.2
+(mac) umac-64@openssh.com                   -- [warn] using encrypt-and-MAC mode
+                                            `- [warn] using small 64-bit tag size
+                                            `- [info] available since OpenSSH 4.7
+(mac) umac-128@openssh.com                  -- [warn] using encrypt-and-MAC mode
+                                            `- [info] available since OpenSSH 6.2
+(mac) hmac-sha2-256                         -- [warn] using encrypt-and-MAC mode
+                                            `- [info] available since OpenSSH 5.9, Dropbear SSH 2013.56
+(mac) hmac-sha2-512                         -- [warn] using encrypt-and-MAC mode
+                                            `- [info] available since OpenSSH 5.9, Dropbear SSH 2013.56
+(mac) hmac-sha1                             -- [warn] using encrypt-and-MAC mode
+                                            `- [warn] using weak hashing algorithm
+                                            `- [info] available since OpenSSH 2.1.0, Dropbear SSH 0.28
+
+# fingerprints
+(fin) ssh-ed25519: SHA256:aZb9pxaiJQJtnn/jH5GIzbMjSxBaYav5P2vMxn0b7Mw
+(fin) ssh-rsa: SHA256:ESKMULAZXZGrEhnlTtUoRFh9VcappnR+9NeBozD+Dso
+
+# algorithm recommendations (for OpenSSH 8.7)
+(rec) -ecdh-sha2-nistp256                   -- kex algorithm to remove
+(rec) -ecdh-sha2-nistp384                   -- kex algorithm to remove
+(rec) -ecdh-sha2-nistp521                   -- kex algorithm to remove
+(rec) -ecdsa-sha2-nistp256                  -- key algorithm to remove
+(rec) -hmac-sha1                            -- mac algorithm to remove
+(rec) -hmac-sha1-etm@openssh.com            -- mac algorithm to remove
+(rec) -hmac-sha2-256                        -- mac algorithm to remove
+(rec) -hmac-sha2-512                        -- mac algorithm to remove
+(rec) -ssh-rsa                              -- key algorithm to remove
+(rec) -umac-128@openssh.com                 -- mac algorithm to remove
+(rec) -umac-64-etm@openssh.com              -- mac algorithm to remove
+(rec) -umac-64@openssh.com                  -- mac algorithm to remove
+
+# additional info
+(nfo) For hardening guides on common OSes, please see: <https://www.ssh-audit.com/hardening_guides.html>
+
+# after hardening
+# general
+(gen) banner: SSH-2.0-OpenSSH_8.7 FreeBSD-20210907
+(gen) software: OpenSSH 8.7 running on FreeBSD (2021-09-07)
+(gen) compatibility: OpenSSH 7.4+, Dropbear SSH 2018.76+
+(gen) compression: enabled (zlib@openssh.com)
+
+# key exchange algorithms
+(kex) curve25519-sha256                     -- [info] available since OpenSSH 7.4, Dropbear SSH 2018.76
+(kex) curve25519-sha256@libssh.org          -- [info] available since OpenSSH 6.5, Dropbear SSH 2013.62
+(kex) diffie-hellman-group16-sha512         -- [info] available since OpenSSH 7.3, Dropbear SSH 2016.73
+(kex) diffie-hellman-group18-sha512         -- [info] available since OpenSSH 7.3
+(kex) diffie-hellman-group-exchange-sha256 (2048-bit) -- [info] available since OpenSSH 4.4
+
+# host-key algorithms
+(key) ssh-ed25519                           -- [info] available since OpenSSH 6.5
+
+# encryption algorithms (ciphers)
+(enc) chacha20-poly1305@openssh.com         -- [info] available since OpenSSH 6.5
+                                            `- [info] default cipher since OpenSSH 6.9.
+(enc) aes256-gcm@openssh.com                -- [info] available since OpenSSH 6.2
+(enc) aes128-gcm@openssh.com                -- [info] available since OpenSSH 6.2
+(enc) aes256-ctr                            -- [info] available since OpenSSH 3.7, Dropbear SSH 0.52
+(enc) aes192-ctr                            -- [info] available since OpenSSH 3.7
+(enc) aes128-ctr                            -- [info] available since OpenSSH 3.7, Dropbear SSH 0.52
+
+# message authentication code algorithms
+(mac) hmac-sha2-256-etm@openssh.com         -- [info] available since OpenSSH 6.2
+(mac) hmac-sha2-512-etm@openssh.com         -- [info] available since OpenSSH 6.2
+(mac) umac-128-etm@openssh.com              -- [info] available since OpenSSH 6.2
+
+# fingerprints
+(fin) ssh-ed25519: SHA256:EfPanpuzqOLlMbZw5gyaA6ZKBPqSdOuS4fWijVJw8tE
+
+# algorithm recommendations (for OpenSSH 8.7)
+(rec) +diffie-hellman-group14-sha256        -- kex algorithm to append
+(rec) +rsa-sha2-256                         -- key algorithm to append
+(rec) +rsa-sha2-512                         -- key algorithm to append
+```
+</details>
 
 ## If you want to revert the SSH configuration
 


### PR DESCRIPTION
FreeBSD 11.4 has reached EoL, remove it from the test matrix and make the tests fail if the second run of `ssh-audit` fails, always uploading the `ssh-audit.out` file as an artifact.

Additional changes:

- Add -STABLE releases to the test matrix
- Include a sample `ssh-audit.out` (collapsible)
- Allow the first run of `ssh-audit` to fail
- Rearrange `uname -a` as the first line
- Specify before and after the hardening