### PR TITLE
Use `rm -f`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Remove existing key-pairs, disable DSA & ECDSA, regenerate RSA and ED25519 keys
 
-    rm /etc/ssh/ssh_host_*
+    rm -f /etc/ssh/ssh_host_*
     sysrc sshd_dsa_enable="no"
     sysrc sshd_ecdsa_enable="no"
     sysrc sshd_ed25519_enable="yes"


### PR DESCRIPTION
It will avoid prompting the user for confirmation, as many times users alias `rm -i` to `rm`.  It will also not fail if the files do not exist.