### PR TITLE
Fix sed's regex for (un)commenting HostKeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@
 
 ## Disable DSA and ECDSA host keys, enable RSA ed25519 host keys
 
-    sed -i .bak 's/^HostKey \/etc\/ssh\/ssh_host_\(dsa\|ecdsa\)_key$/\#HostKey \/etc\/ssh\/ssh_host_\1_key/g; s/^#HostKey \/etc\/ssh\/ssh_host_\(rsa\|ed25519\)_key$/\HostKey \/etc\/ssh\/ssh_host_\1_key/g' /etc/ssh/sshd_config
+    sed -i '' -E 's%^#?HostKey /etc/ssh/ssh_host_(dsa|ecdsa)_key%#HostKey /etc/ssh/ssh_host_\1_key%' /etc/ssh/sshd_config
+    sed -i '' -E 's%^#?HostKey /etc/ssh/ssh_host_(rsa|ed25519)_key%HostKey /etc/ssh/ssh_host_\1_key%' /etc/ssh/sshd_config
 
 ## Restrict supported key exchange, cipher, and MAC algorithms
 


### PR DESCRIPTION
- Avoid leaning toothpick syndrome by using `%` as delimiter

- Split line into two separate lines, one for disabling, the other one for enabling, improving the readability of the intended change

**NB**: Not sure if this step has any real benefit.  Before this change it was a noop.  Now, it is still a futile noop [1].

[1]: Per `sshd_config(5)`, this directive is for specifying different key files, or to have multiple ones, `HostKeyAlgorithms` restricts which of the keys are actually used.