### PR TITLE
Update supported algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Restrict supported key exchange, cipher, and MAC algorithms
 
-    printf "\n# Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com\n# hardening guide.\nKexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256,diffie-hellman-group-exchange-sha256\nCiphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr\nMACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com\nHostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com\n" >> /etc/ssh/sshd_config
+    printf "\n# Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com\n# hardening guide.\nKexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256,diffie-hellman-group-exchange-sha256\nCiphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr\nMACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com\nHostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com\n" >> /etc/ssh/sshd_config
 
 ## Restart sshd and run ssh-audit again, appending output
 


### PR DESCRIPTION
This is based on supported algorithms under FreeBSD 13.2 RELEASE, reported by `ssh -Q kex` and `ssh -Q key`, and some pointers from the [Ubuntu 22.02 LTS SSH hardening](https://www.sshaudit.com/hardening_guides.html#ubuntu_22_04_lts) guide.

- KexAlgorithms inserted `sntrup761x25519-sha512@openssh.com` as primary.
- HostKeyAlgorithms added `sk-ssh-ed25519@openssh.com` and `sk-ssh-ed25519-cert-v01@openssh.com`.
- HostKeyAlgorithms re-ordered `rsa-sha2-512`, `rsa-sha2-512-cert-v01@openssh.com`, `rsa-sha2-256`, `rsa-sha2-256-cert-v01@openssh.com`.

Successfully tested host of FreeBSD 13.2 RELEASE (Arch client).  I submit this for scrutiny by those with undoubtedly better knowledge of the algorithms than I.