### PR TITLE
Update algorithms based on FreeBSD 13.2 RELEASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Restrict supported key exchange, cipher, and MAC algorithms
 
-    printf "\n# Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com\n# hardening guide.\nKexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256,diffie-hellman-group-exchange-sha256\nCiphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr\nMACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com\nHostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com\n" >> /etc/ssh/sshd_config
+    printf "\n# Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com\n# hardening guide.\nKexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256,diffie-hellman-group-exchange-sha256\nCiphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr\nMACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com\nHostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com\n" >> /etc/ssh/sshd_config
 
 ## Restart sshd and run ssh-audit again, appending output
 


### PR DESCRIPTION
Includes support for sntrup761x25519-sha512@openssh.com key exchange algorithm, introduced with OpenSSH 8.9, I believe.

Likely not supported by FreeBSD releases prior to FreeBSD 13.2-RELEASE (OpenSSH 9.2p1) , or FreeBSD 12.4-RELEASE (OpenSSH 9.1p1).
FreeBSD 13.1-RELEASE used OpenSSH 8.8p1.
FreeBSD 12.3-RELEASE may have used OpenSSH 7.9p1?

KexAlgorithms inserted sntrup761x25519-sha512@openssh.com as primary.
HostKeyAlgorithms added sk-ssh-ed25519@openssh.com and sk-ssh-ed25519-cert-v01@openssh.com.
HostKeyAlgorithms re-ordered rsa-sha2-512, rsa-sha2-512-cert-v01@openssh.com, rsa-sha2-256, rsa-sha2-256-cert-v01@openssh.com.