### PR TITLE
Update tested releases

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,12 +10,12 @@ task:
     - name: 13.2-RELEASE
       freebsd_instance:
         image_family: freebsd-13-2
-#   - name: 13.2-STABLE
-#     freebsd_instance:
-#       image_family: freebsd-13-2-snap
-#   - name: 14.0-CURRENT
-#     freebsd_instance:
-#       image_family: freebsd-14-0-snap
+    - name: 13.2-STABLE
+      freebsd_instance:
+        image_family: freebsd-13-2-snap
+    - name: 14.0-CURRENT
+      freebsd_instance:
+        image_family: freebsd-14-0-snap
   ssh-hardening_script:
     - sed -i '' 's/^/#/' README.md
     - sed -i '' '/^#         .*$/d' README.md

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,18 +1,18 @@
 # Test the documentation on SSH hardening
 task:
   matrix:
-    - name: 12.2-RELEASE
+    - name: 12.4-RELEASE
       freebsd_instance:
-        image_family: freebsd-12-2
-    - name: 12.2-STABLE
+        image_family: freebsd-12-4
+    - name: 12.4-STABLE
       freebsd_instance:
-        image_family: freebsd-12-2-snap
-    - name: 13.0-RELEASE
+        image_family: freebsd-12-4-snap
+    - name: 13.2-RELEASE
       freebsd_instance:
-        image_family: freebsd-13-0
-    - name: 13.0-STABLE
+        image_family: freebsd-13-2
+    - name: 13.2-STABLE
       freebsd_instance:
-        image_family: freebsd-13-0-snap
+        image_family: freebsd-13-2-snap
     - name: 14.0-CURRENT
       freebsd_instance:
         image_family: freebsd-14-0-snap

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,12 +10,12 @@ task:
     - name: 13.2-RELEASE
       freebsd_instance:
         image_family: freebsd-13-2
-    - name: 13.2-STABLE
-      freebsd_instance:
-        image_family: freebsd-13-2-snap
-    - name: 14.0-CURRENT
-      freebsd_instance:
-        image_family: freebsd-14-0-snap
+#   - name: 13.2-STABLE
+#     freebsd_instance:
+#       image_family: freebsd-13-2-snap
+#   - name: 14.0-CURRENT
+#     freebsd_instance:
+#       image_family: freebsd-14-0-snap
   ssh-hardening_script:
     - sed -i '' 's/^/#/' README.md
     - sed -i '' '/^#         .*$/d' README.md

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Restrict supported key exchange, cipher, and MAC algorithms
 
-    printf "\n# Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com\n# hardening guide.\nKexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256\nCiphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr\nMACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com\nHostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com" >> /etc/ssh/sshd_config
+    printf "\n# Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com\n# hardening guide.\nKexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512\nCiphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr\nMACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com\nHostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com" >> /etc/ssh/sshd_config
 
 ## Restart sshd and run ssh-audit again, appending output
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Restrict supported key exchange, cipher, and MAC algorithms
 
-    printf "\n# Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com\n# hardening guide.\nKexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512\nCiphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr\nMACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com\nHostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com" >> /etc/ssh/sshd_config
+    printf "\n# Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com\n# hardening guide.\nKexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256\nCiphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr\nMACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com\nHostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com" >> /etc/ssh/sshd_config
 
 ## Restart sshd and run ssh-audit again, appending output
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Restrict supported key exchange, cipher, and MAC algorithms
 
-    printf "\n# Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com\n# hardening guide.\nKexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256\nCiphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr\nMACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com\nHostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com" >> /etc/ssh/sshd_config
+    printf "\n# Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com\n# hardening guide.\nKexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256\nCiphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr\nMACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com\nHostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com\n" >> /etc/ssh/sshd_config
 
 ## Restart sshd and run ssh-audit again, appending output
 

--- a/README.md
+++ b/README.md
@@ -48,42 +48,45 @@
   <summary>Send (pastebin) the contents of <code>ssh-audit.out</code></summary>
 
 ```
-FreeBSD cirrus-task-0000000000000000 14.0-CURRENT FreeBSD 14.0-CURRENT #0 main-n249268-58a7bf124cc: Thu Sep  9 12:00:00 UTC 2021     root@releng1.nyi.freebsd.org:/usr/obj/usr/src/amd64.amd64/sys/GENERIC  amd64
+FreeBSD cirrus-task-5888949290270720 14.0-CURRENT FreeBSD 14.0-CURRENT #0 main-n262122-2ef2c26f3f13: Thu Apr 13 08:06:35 UTC 2023     root@releng1.nyi.freebsd.org:/usr/obj/usr/src/amd64.amd64/sys/GENERIC amd64
 # before hardening
 # general
-(gen) banner: SSH-2.0-OpenSSH_8.7 FreeBSD-20210907
-(gen) software: OpenSSH 8.7 running on FreeBSD (2021-09-07)
-(gen) compatibility: OpenSSH 7.4+, Dropbear SSH 2018.76+
+(gen) banner: SSH-2.0-OpenSSH_9.3 FreeBSD-20230316
+(gen) software: OpenSSH 9.3 running on FreeBSD (2023-03-16)
+(gen) compatibility: OpenSSH 8.5+, Dropbear SSH 2018.76+
 (gen) compression: enabled (zlib@openssh.com)
 
 # key exchange algorithms
+(kex) sntrup761x25519-sha512@openssh.com    -- [info] available since OpenSSH 8.5
 (kex) curve25519-sha256                     -- [info] available since OpenSSH 7.4, Dropbear SSH 2018.76
-(kex) curve25519-sha256@libssh.org          -- [info] available since OpenSSH 6.5, Dropbear SSH 2013.62
-(kex) ecdh-sha2-nistp256                    -- [fail] using weak elliptic curves
+                                            `- [info] default key exchange since OpenSSH 6.4
+(kex) curve25519-sha256@libssh.org          -- [info] available since OpenSSH 6.4, Dropbear SSH 2013.62
+                                            `- [info] default key exchange since OpenSSH 6.4
+(kex) ecdh-sha2-nistp256                    -- [fail] using elliptic curves that are suspected as being backdoored by the U.S. National Security Agency
                                             `- [info] available since OpenSSH 5.7, Dropbear SSH 2013.62
-(kex) ecdh-sha2-nistp384                    -- [fail] using weak elliptic curves
+(kex) ecdh-sha2-nistp384                    -- [fail] using elliptic curves that are suspected as being backdoored by the U.S. National Security Agency
                                             `- [info] available since OpenSSH 5.7, Dropbear SSH 2013.62
-(kex) ecdh-sha2-nistp521                    -- [fail] using weak elliptic curves
+(kex) ecdh-sha2-nistp521                    -- [fail] using elliptic curves that are suspected as being backdoored by the U.S. National Security Agency
                                             `- [info] available since OpenSSH 5.7, Dropbear SSH 2013.62
-(kex) diffie-hellman-group-exchange-sha256 (2048-bit) -- [info] available since OpenSSH 4.4
+(kex) diffie-hellman-group-exchange-sha256 (2048-bit) -- [warn] 2048-bit modulus only provides 112-bits of symmetric strength
+                                                      `- [info] available since OpenSSH 4.4
+                                                      `- [info] A bug in OpenSSH causes it to fall back to a 2048-bit modulus regardless of server configuration (https://bugzilla.mindrot.org/show_bug.cgi?id=2793)
 (kex) diffie-hellman-group16-sha512         -- [info] available since OpenSSH 7.3, Dropbear SSH 2016.73
 (kex) diffie-hellman-group18-sha512         -- [info] available since OpenSSH 7.3
-(kex) diffie-hellman-group14-sha256         -- [info] available since OpenSSH 7.3, Dropbear SSH 2016.73
+(kex) diffie-hellman-group14-sha256         -- [warn] 2048-bit modulus only provides 112-bits of symmetric strength
+                                            `- [info] available since OpenSSH 7.3, Dropbear SSH 2016.73
 
 # host-key algorithms
 (key) rsa-sha2-512 (3072-bit)               -- [info] available since OpenSSH 7.2
 (key) rsa-sha2-256 (3072-bit)               -- [info] available since OpenSSH 7.2
-(key) ssh-rsa (3072-bit)                    -- [fail] using weak hashing algorithm
-                                            `- [info] available since OpenSSH 2.5.0, Dropbear SSH 0.28
-                                            `- [info] a future deprecation notice has been issued in OpenSSH 8.2: https://www.openssh.com/txt/release-8.2
-(key) ecdsa-sha2-nistp256                   -- [fail] using weak elliptic curves
+(key) ecdsa-sha2-nistp256                   -- [fail] using elliptic curves that are suspected as being backdoored by the U.S. National Security Agency
                                             `- [warn] using weak random number generator could reveal the key
                                             `- [info] available since OpenSSH 5.7, Dropbear SSH 2013.62
 (key) ssh-ed25519                           -- [info] available since OpenSSH 6.5
 
 # encryption algorithms (ciphers)
 (enc) chacha20-poly1305@openssh.com         -- [info] available since OpenSSH 6.5
-                                            `- [info] default cipher since OpenSSH 6.9.
+                                            `- [info] default cipher since OpenSSH 6.9
 (enc) aes128-ctr                            -- [info] available since OpenSSH 3.7, Dropbear SSH 0.52
 (enc) aes192-ctr                            -- [info] available since OpenSSH 3.7
 (enc) aes256-ctr                            -- [info] available since OpenSSH 3.7, Dropbear SSH 0.52
@@ -96,7 +99,7 @@ FreeBSD cirrus-task-0000000000000000 14.0-CURRENT FreeBSD 14.0-CURRENT #0 main-n
 (mac) umac-128-etm@openssh.com              -- [info] available since OpenSSH 6.2
 (mac) hmac-sha2-256-etm@openssh.com         -- [info] available since OpenSSH 6.2
 (mac) hmac-sha2-512-etm@openssh.com         -- [info] available since OpenSSH 6.2
-(mac) hmac-sha1-etm@openssh.com             -- [warn] using weak hashing algorithm
+(mac) hmac-sha1-etm@openssh.com             -- [fail] using broken SHA-1 hash algorithm
                                             `- [info] available since OpenSSH 6.2
 (mac) umac-64@openssh.com                   -- [warn] using encrypt-and-MAC mode
                                             `- [warn] using small 64-bit tag size
@@ -107,15 +110,16 @@ FreeBSD cirrus-task-0000000000000000 14.0-CURRENT FreeBSD 14.0-CURRENT #0 main-n
                                             `- [info] available since OpenSSH 5.9, Dropbear SSH 2013.56
 (mac) hmac-sha2-512                         -- [warn] using encrypt-and-MAC mode
                                             `- [info] available since OpenSSH 5.9, Dropbear SSH 2013.56
-(mac) hmac-sha1                             -- [warn] using encrypt-and-MAC mode
-                                            `- [warn] using weak hashing algorithm
+(mac) hmac-sha1                             -- [fail] using broken SHA-1 hash algorithm
+                                            `- [warn] using encrypt-and-MAC mode
                                             `- [info] available since OpenSSH 2.1.0, Dropbear SSH 0.28
 
 # fingerprints
-(fin) ssh-ed25519: SHA256:aZb9pxaiJQJtnn/jH5GIzbMjSxBaYav5P2vMxn0b7Mw
-(fin) ssh-rsa: SHA256:ESKMULAZXZGrEhnlTtUoRFh9VcappnR+9NeBozD+Dso
+(fin) ssh-ed25519: SHA256:/hJ2MWfjsOAIdQbz1WT0I6BPiXveLmN/w8NYpFl+xIM
+(fin) ssh-rsa: SHA256:SoCaYwWS1fKwbXwT2F044FhZ5gijwy/wDmLemgzoqW0
 
-# algorithm recommendations (for OpenSSH 8.7)
+# algorithm recommendations (for OpenSSH 9.3)
+(rec) -diffie-hellman-group14-sha256        -- kex algorithm to remove
 (rec) -ecdh-sha2-nistp256                   -- kex algorithm to remove
 (rec) -ecdh-sha2-nistp384                   -- kex algorithm to remove
 (rec) -ecdh-sha2-nistp521                   -- kex algorithm to remove
@@ -124,7 +128,6 @@ FreeBSD cirrus-task-0000000000000000 14.0-CURRENT FreeBSD 14.0-CURRENT #0 main-n
 (rec) -hmac-sha1-etm@openssh.com            -- mac algorithm to remove
 (rec) -hmac-sha2-256                        -- mac algorithm to remove
 (rec) -hmac-sha2-512                        -- mac algorithm to remove
-(rec) -ssh-rsa                              -- key algorithm to remove
 (rec) -umac-128@openssh.com                 -- mac algorithm to remove
 (rec) -umac-64-etm@openssh.com              -- mac algorithm to remove
 (rec) -umac-64@openssh.com                  -- mac algorithm to remove
@@ -134,18 +137,22 @@ FreeBSD cirrus-task-0000000000000000 14.0-CURRENT FreeBSD 14.0-CURRENT #0 main-n
 
 # after hardening
 # general
-(gen) banner: SSH-2.0-OpenSSH_8.7 FreeBSD-20210907
-(gen) software: OpenSSH 8.7 running on FreeBSD (2021-09-07)
-(gen) compatibility: OpenSSH 7.4+, Dropbear SSH 2018.76+
+(gen) banner: SSH-2.0-OpenSSH_9.3 FreeBSD-20230316
+(gen) software: OpenSSH 9.3 running on FreeBSD (2023-03-16)
+(gen) compatibility: OpenSSH 8.5+, Dropbear SSH 2018.76+
 (gen) compression: enabled (zlib@openssh.com)
 
 # key exchange algorithms
+(kex) sntrup761x25519-sha512@openssh.com    -- [info] available since OpenSSH 8.5
 (kex) curve25519-sha256                     -- [info] available since OpenSSH 7.4, Dropbear SSH 2018.76
-(kex) curve25519-sha256@libssh.org          -- [info] available since OpenSSH 6.5, Dropbear SSH 2013.62
+                                            `- [info] default key exchange since OpenSSH 6.4
+(kex) curve25519-sha256@libssh.org          -- [info] available since OpenSSH 6.4, Dropbear SSH 2013.62
+                                            `- [info] default key exchange since OpenSSH 6.4
 (kex) diffie-hellman-group16-sha512         -- [info] available since OpenSSH 7.3, Dropbear SSH 2016.73
 (kex) diffie-hellman-group18-sha512         -- [info] available since OpenSSH 7.3
-(kex) diffie-hellman-group14-sha256         -- [info] available since OpenSSH 7.3, Dropbear SSH 2016.73
-(kex) diffie-hellman-group-exchange-sha256 (2048-bit) -- [info] available since OpenSSH 4.4
+(kex) diffie-hellman-group-exchange-sha256 (2048-bit) -- [warn] 2048-bit modulus only provides 112-bits of symmetric strength
+                                                      `- [info] available since OpenSSH 4.4
+                                                      `- [info] A bug in OpenSSH causes it to fall back to a 2048-bit modulus regardless of server configuration (https://bugzilla.mindrot.org/show_bug.cgi?id=2793)
 
 # host-key algorithms
 (key) rsa-sha2-512 (3072-bit)               -- [info] available since OpenSSH 7.2
@@ -154,7 +161,7 @@ FreeBSD cirrus-task-0000000000000000 14.0-CURRENT FreeBSD 14.0-CURRENT #0 main-n
 
 # encryption algorithms (ciphers)
 (enc) chacha20-poly1305@openssh.com         -- [info] available since OpenSSH 6.5
-                                            `- [info] default cipher since OpenSSH 6.9.
+                                            `- [info] default cipher since OpenSSH 6.9
 (enc) aes256-gcm@openssh.com                -- [info] available since OpenSSH 6.2
 (enc) aes128-gcm@openssh.com                -- [info] available since OpenSSH 6.2
 (enc) aes256-ctr                            -- [info] available since OpenSSH 3.7, Dropbear SSH 0.52
@@ -167,8 +174,8 @@ FreeBSD cirrus-task-0000000000000000 14.0-CURRENT FreeBSD 14.0-CURRENT #0 main-n
 (mac) umac-128-etm@openssh.com              -- [info] available since OpenSSH 6.2
 
 # fingerprints
-(fin) ssh-ed25519: SHA256:EfPanpuzqOLlMbZw5gyaA6ZKBPqSdOuS4fWijVJw8tE
-(fin) ssh-rsa: SHA256:P/vQR180OHayS+S59ZbVqVR69GgTCD6pDuFnMZnyees
+(fin) ssh-ed25519: SHA256:i0cwnGF12eus8bX7A+cw2hq+ZqBmP6hceYBuQLHnTP4
+(fin) ssh-rsa: SHA256:fFc5jCYQwcyrR2UjlNSPhTYtFDWfhLitmtoU2p0BcmM
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
   <summary>Send (pastebin) the contents of <code>ssh-audit.out</code></summary>
 
 ```
-FreeBSD cirrus-task-5888949290270720 14.0-CURRENT FreeBSD 14.0-CURRENT #0 main-n262122-2ef2c26f3f13: Thu Apr 13 08:06:35 UTC 2023     root@releng1.nyi.freebsd.org:/usr/obj/usr/src/amd64.amd64/sys/GENERIC amd64
+FreeBSD cirrus-task-0000000000000000 14.0-CURRENT FreeBSD 14.0-CURRENT #0 main-n262122-2ef2c26f3f13: Thu Apr 13 12:00:00 UTC 2023     root@releng1.nyi.freebsd.org:/usr/obj/usr/src/amd64.amd64/sys/GENERIC amd64
 # before hardening
 # general
 (gen) banner: SSH-2.0-OpenSSH_9.3 FreeBSD-20230316

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Restrict supported key exchange, cipher, and MAC algorithms
 
-    printf "\n# Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com\n# hardening guide.\nKexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256,diffie-hellman-group-exchange-sha256\nCiphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr\nMACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com\nHostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com\n" >> /etc/ssh/sshd_config
+    printf "\n# Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com\n# hardening guide.\nKexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,gss-curve25519-sha256-,diffie-hellman-group16-sha512,gss-group16-sha512-,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256\nCiphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr\nMACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com\nHostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com" >> /etc/ssh/sshd_config
 
 ## Restart sshd and run ssh-audit again, appending output
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Restrict supported key exchange, cipher, and MAC algorithms
 
-    printf "\n# Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com\n# hardening guide.\nKexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,gss-group16-sha512-,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256\nCiphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr\nMACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com\nHostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com" >> /etc/ssh/sshd_config
+    printf "\n# Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com\n# hardening guide.\nKexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256\nCiphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr\nMACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com\nHostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com" >> /etc/ssh/sshd_config
 
 ## Restart sshd and run ssh-audit again, appending output
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Restrict supported key exchange, cipher, and MAC algorithms
 
-    printf "\n# Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com\n# hardening guide.\nKexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,gss-curve25519-sha256-,diffie-hellman-group16-sha512,gss-group16-sha512-,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256\nCiphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr\nMACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com\nHostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com" >> /etc/ssh/sshd_config
+    printf "\n# Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com\n# hardening guide.\nKexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,gss-group16-sha512-,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256\nCiphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr\nMACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com\nHostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com" >> /etc/ssh/sshd_config
 
 ## Restart sshd and run ssh-audit again, appending output
 


### PR DESCRIPTION
- Bump FreeBSD versions tested
- Match Ubuntu 22.04 LTS Server guide

> **Warning**
> **All tests are failing**:
> - On -RELEASE branches, the package version is still 2.5.0
> - On -STABLE and -CURRENT branches, the package version is 2.9.0, but it warns about "`2048-bit modulus only provides 112-bits of symmetric strength`", something that will likely never be accepted upstream, this aligns to the fact that we could never attain 100% using non-elliptic curve keys.

---

Close #16
Close #17