### PR TITLE
Make tests green

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,6 +16,9 @@ task:
     - name: 14.0-CURRENT
       freebsd_instance:
         image_family: freebsd-14-0-snap
+  use_latest_packages_script:
+    - mkdir -p /usr/local/etc/pkg/repos
+    - cp .cirrus/FreeBSD.conf /usr/local/etc/pkg/repos/
   ssh-hardening_script:
     - sed -i '' 's/^/#/' README.md
     - sed -i '' '/^#         .*$/d' README.md

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,8 +20,10 @@ task:
     - sed -i '' 's/^/#/' README.md
     - sed -i '' '/^#         .*$/d' README.md
     - sed -i '' 's/^#    //' README.md
-    - printf "#\!/bin/sh\nset -e\n%s\n" "$(cat README.md)" > ssh-hardening.sh
+    - printf "#\!/bin/sh\n%s\n" "$(cat README.md)" > ssh-hardening.sh
     - sh ./ssh-hardening.sh
+    - sh .cirrus/check_for_recommendations.sh
+
   always:
     ssh-audit.out_artifacts:
       path: ssh-audit.out

--- a/.cirrus/FreeBSD.conf
+++ b/.cirrus/FreeBSD.conf
@@ -1,0 +1,3 @@
+FreeBSD: {
+  url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest"
+}

--- a/.cirrus/FreeBSD.conf
+++ b/.cirrus/FreeBSD.conf
@@ -1,3 +1,3 @@
 FreeBSD: {
-  url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest"
+  url: "pkg+http://pkg.FreeBSD.org//latest"
 }

--- a/.cirrus/check_for_recommendations.sh
+++ b/.cirrus/check_for_recommendations.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Check if there are still recommendations present,
+# and consider them as failures.
+
+cp ssh-audit.out ssh-audit-after-hardening.out
+sed -i '' '1,/# after hardening/d' ssh-audit-after-hardening.out
+recommendations=$(grep -c recommendations ssh-audit-after-hardening.out)
+
+if [ "$recommendations" -ne 0 ]; then
+	exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 [![Build Status](https://api.cirrus-ci.com/github/bsdlabs/ssh-hardening.svg)](https://cirrus-ci.com/github/bsdlabs/ssh-hardening)
 
-> **Warning**
-> **All tests are failing**:
-> - On -RELEASE branches, the package version is still 2.5.0
-> - On -STABLE and -CURRENT branches, the package version is 2.9.0, but it warns about "`2048-bit modulus only provides 112-bits of symmetric strength`", something that will likely never be accepted upstream, this aligns to the fact that we could never attain 100% using non-elliptic curve keys.
-
 # FreeBSD SSH Hardening
 
 ## Backup ssh config, install ssh-audit


### PR DESCRIPTION
Do not consider the exit status of the script as an indication of success.  The most recent version warns about "`2048-bit modulus only provides 112-bits of symmetric strength`", something that will likely never be accepted upstream.

Let's check if there are still recommendations present, and consider them as failures.

- [x] Always use the latest package version.