### PR TITLE
Comparative table: Remove KEX algorithm

### DIFF
--- a/server.md
+++ b/server.md
@@ -253,7 +253,6 @@ FreeBSD cirrus-task-0000000000000000 14.0-CURRENT FreeBSD 14.0-CURRENT #0 main-n
 <li>curve25519-sha256@libssh.org</li>
 <li>diffie-hellman-group16-sha512</li>
 <li>diffie-hellman-group18-sha512</li>
-<li>diffie-hellman-group14-sha256</li>
 <li>diffie-hellman-group-exchange-sha256</li>
 </ul>
 </td>


### PR DESCRIPTION
The key exchange algorithm `diffie-hellman-group14-sha256` is in the list of algorithms to remove, and is not present in the hardened configuration.

Remove from the table.

Close #24.