### PR TITLE
Display individual test results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,27 @@
-[![Build Status](https://api.cirrus-ci.com/github/bsdlabs/ssh-hardening.svg)](https://cirrus-ci.com/github/bsdlabs/ssh-hardening)
+| Guide | 12.4-RELEASE | 12.4-STABLE | 13.2-RELEASE | 13.2-STABLE | 14.0-CURRENT |
+| -----:|:------------:|:-----------:|:------------:|:-----------:|:------------:|
+| [Server][Server Guide] | [![12.4-RELEASE][server-12-4-release-badge]][builds] | [![12.4-STABLE][server-12-4-stable-badge]][builds] | [![13.2-RELEASE][server-13-2-release-badge]][builds] | [![13.2-STABLE][server-13-2-stable-badge]][builds] | [![14.0-CURRENT][server-14-0-current-badge]][builds] |
+| [Client][Client Guide] | [![12.4-RELEASE][client-12-4-release-badge]][builds] | [![12.4-STABLE][client-12-4-stable-badge]][builds] | [![13.2-RELEASE][client-13-2-release-badge]][builds] | [![13.2-STABLE][client-13-2-stable-badge]][builds] | [![14.0-CURRENT][client-14-0-current-badge]][builds] |
+
+[server-12-4-release-badge]: https://api.cirrus-ci.com/github/bsdlabs/ssh-hardening.svg?task=Server%2012.4-RELEASE
+[server-12-4-stable-badge]: https://api.cirrus-ci.com/github/bsdlabs/ssh-hardening.svg?task=Server%2012.4-STABLE
+[server-13-2-release-badge]: https://api.cirrus-ci.com/github/bsdlabs/ssh-hardening.svg?task=Server%2013.2-RELEASE
+[server-13-2-stable-badge]: https://api.cirrus-ci.com/github/bsdlabs/ssh-hardening.svg?task=Server%2013.2-STABLE
+[server-14-0-current-badge]: https://api.cirrus-ci.com/github/bsdlabs/ssh-hardening.svg?task=Server%2014.0-CURRENT
+[client-12-4-release-badge]: https://api.cirrus-ci.com/github/bsdlabs/ssh-hardening.svg?task=Client%2012.4-RELEASE
+[client-12-4-stable-badge]: https://api.cirrus-ci.com/github/bsdlabs/ssh-hardening.svg?task=Client%2012.4-STABLE
+[client-13-2-release-badge]: https://api.cirrus-ci.com/github/bsdlabs/ssh-hardening.svg?task=Client%2013.2-RELEASE
+[client-13-2-stable-badge]: https://api.cirrus-ci.com/github/bsdlabs/ssh-hardening.svg?task=Client%2013.2-STABLE
+[client-14-0-current-badge]: https://api.cirrus-ci.com/github/bsdlabs/ssh-hardening.svg?task=Client%2014.0-CURRENT
+[builds]: https://cirrus-ci.com/github/bsdlabs/ssh-hardening/main
 
 # FreeBSD OpenSSH Hardening Guides
 
 Below are guides to harden OpenSSH on FreeBSD.  These instructions will result in the best possible score as of 2023-05-06.
 
-[Server Guide](server.md)
+[Server Guide]
 
-[Client Guide](client.md)
+[Client Guide]
+
+[Server Guide]: server.md
+[Client Guide]: client.md


### PR DESCRIPTION
It was asked when upstreaming the guides for which specific versions the guides were tested against.

Let's also display this information, without the need to open the CirrusCI file.